### PR TITLE
Fixed version conflict with dart 2.1.0/flutter 0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   cupertino_icons: ^0.1.0
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.0.0-dev.58.0 <3.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,9 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.0
 
+environment:
+  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Check https://github.com/flutter/flutter/issues/20700 for more info.

Issue is resolved by just setting a minimum environment version for the
plugin.

Closes:
https://github.com/ezrasandzerbell/FLUTTER-carousel-demo/issues/1